### PR TITLE
Add export build_type in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -7,4 +7,7 @@
   <license>BSD-3-Clause</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>  


### PR DESCRIPTION
Without it, llh_conveter cannot be registered in AMENT_PREFIX_PATH and cannot be searched by "ros2 pkg list | grep llh" or ament_index_cpp::get_package_share_directory.