### PR TITLE
Add constructor with arguments

### DIFF
--- a/include/llh_converter/llh_converter.hpp
+++ b/include/llh_converter/llh_converter.hpp
@@ -67,6 +67,7 @@ class LLHConverter
 {
 public:
   LLHConverter();
+  LLHConverter(const std::string& geoid_file);
 
   void convertDeg2XYZ(const double& lat_deg, const double& lon_deg, const double& h, double& x, double& y, double& z,
                       const LLHParam& param);

--- a/include/llh_converter/llh_converter.hpp
+++ b/include/llh_converter/llh_converter.hpp
@@ -124,6 +124,7 @@ private:
   void setPlaneNum(int plane_num);
 
   boost::bimaps::bimap<std::string, int> mgrs_alphabet_;
+  void initializeMgrsAlphabet();
 };
 }  // namespace llh_converter
 

--- a/include/llh_converter/llh_converter.hpp
+++ b/include/llh_converter/llh_converter.hpp
@@ -124,7 +124,7 @@ private:
   void setPlaneNum(int plane_num);
 
   boost::bimaps::bimap<std::string, int> mgrs_alphabet_;
-  void initializeMgrsAlphabet();
+  void initializeMGRSAlphabet();
 };
 }  // namespace llh_converter
 

--- a/src/llh_converter.cpp
+++ b/src/llh_converter.cpp
@@ -50,21 +50,13 @@ makeBimap(std::initializer_list<typename boost::bimaps::bimap<L, R>::value_type>
 LLHConverter::LLHConverter()
 {
   height_converter_.loadGSIGEOGeoidFile();
-  mgrs_alphabet_ = makeBimap<std::string, int>({ { "A", 0 },  { "B", 1 },  { "C", 2 },  { "D", 3 },  { "E", 4 },
-                                                 { "F", 5 },  { "G", 6 },  { "H", 7 },  { "J", 8 },  { "K", 9 },
-                                                 { "L", 10 }, { "M", 11 }, { "N", 12 }, { "P", 13 }, { "Q", 14 },
-                                                 { "R", 15 }, { "S", 16 }, { "T", 17 }, { "U", 18 }, { "V", 19 },
-                                                 { "W", 20 }, { "X", 21 }, { "Y", 22 }, { "Z", 23 } });
+  initializeMgrsAlphabet();
 }
 
 LLHConverter::LLHConverter(const std::string& geoid_file)
 {
   height_converter_.loadGSIGEOGeoidFile(geoid_file);
-  mgrs_alphabet_ = makeBimap<std::string, int>({ { "A", 0 },  { "B", 1 },  { "C", 2 },  { "D", 3 },  { "E", 4 },
-                                                 { "F", 5 },  { "G", 6 },  { "H", 7 },  { "J", 8 },  { "K", 9 },
-                                                 { "L", 10 }, { "M", 11 }, { "N", 12 }, { "P", 13 }, { "Q", 14 },
-                                                 { "R", 15 }, { "S", 16 }, { "T", 17 }, { "U", 18 }, { "V", 19 },
-                                                 { "W", 20 }, { "X", 21 }, { "Y", 22 }, { "Z", 23 } });
+  initializeMgrsAlphabet();
 }
 
 // Public fumember functions
@@ -626,5 +618,14 @@ void LLHConverter::setPlaneNum(int plane_num)
   // swap longitude and latitude
   plane_lat_rad_ = M_PI * ((double)lat_deg + (double)lat_min / 60.0) / 180.0;
   plane_lon_rad_ = M_PI * ((double)lon_deg + (double)lon_min / 60.0) / 180.0;
+}
+
+void LLHConverter::initializeMgrsAlphabet()
+{
+    mgrs_alphabet_ = makeBimap<std::string, int>({ { "A", 0 },  { "B", 1 },  { "C", 2 },  { "D", 3 },  { "E", 4 },
+                                                   { "F", 5 },  { "G", 6 },  { "H", 7 },  { "J", 8 },  { "K", 9 },
+                                                   { "L", 10 }, { "M", 11 }, { "N", 12 }, { "P", 13 }, { "Q", 14 },
+                                                   { "R", 15 }, { "S", 16 }, { "T", 17 }, { "U", 18 }, { "V", 19 },
+                                                   { "W", 20 }, { "X", 21 }, { "Y", 22 }, { "Z", 23 } });
 }
 }  // namespace llh_converter

--- a/src/llh_converter.cpp
+++ b/src/llh_converter.cpp
@@ -50,13 +50,13 @@ makeBimap(std::initializer_list<typename boost::bimaps::bimap<L, R>::value_type>
 LLHConverter::LLHConverter()
 {
   height_converter_.loadGSIGEOGeoidFile();
-  initializeMgrsAlphabet();
+  initializeMGRSAlphabet();
 }
 
 LLHConverter::LLHConverter(const std::string& geoid_file)
 {
   height_converter_.loadGSIGEOGeoidFile(geoid_file);
-  initializeMgrsAlphabet();
+  initializeMGRSAlphabet();
 }
 
 // Public fumember functions
@@ -620,7 +620,7 @@ void LLHConverter::setPlaneNum(int plane_num)
   plane_lon_rad_ = M_PI * ((double)lon_deg + (double)lon_min / 60.0) / 180.0;
 }
 
-void LLHConverter::initializeMgrsAlphabet()
+void LLHConverter::initializeMGRSAlphabet()
 {
     mgrs_alphabet_ = makeBimap<std::string, int>({ { "A", 0 },  { "B", 1 },  { "C", 2 },  { "D", 3 },  { "E", 4 },
                                                    { "F", 5 },  { "G", 6 },  { "H", 7 },  { "J", 8 },  { "K", 9 },

--- a/src/llh_converter.cpp
+++ b/src/llh_converter.cpp
@@ -67,7 +67,6 @@ LLHConverter::LLHConverter(const std::string& geoid_file)
                                                  { "W", 20 }, { "X", 21 }, { "Y", 22 }, { "Z", 23 } });
 }
 
-
 // Public fumember functions
 void LLHConverter::convertDeg2XYZ(const double& lat_deg, const double& lon_deg, const double& h, double& x, double& y,
                                   double& z, const LLHParam& param)

--- a/src/llh_converter.cpp
+++ b/src/llh_converter.cpp
@@ -57,6 +57,17 @@ LLHConverter::LLHConverter()
                                                  { "W", 20 }, { "X", 21 }, { "Y", 22 }, { "Z", 23 } });
 }
 
+LLHConverter::LLHConverter(const std::string& geoid_file)
+{
+  height_converter_.loadGSIGEOGeoidFile(geoid_file);
+  mgrs_alphabet_ = makeBimap<std::string, int>({ { "A", 0 },  { "B", 1 },  { "C", 2 },  { "D", 3 },  { "E", 4 },
+                                                 { "F", 5 },  { "G", 6 },  { "H", 7 },  { "J", 8 },  { "K", 9 },
+                                                 { "L", 10 }, { "M", 11 }, { "N", 12 }, { "P", 13 }, { "Q", 14 },
+                                                 { "R", 15 }, { "S", 16 }, { "T", 17 }, { "U", 18 }, { "V", 19 },
+                                                 { "W", 20 }, { "X", 21 }, { "Y", 22 }, { "Z", 23 } });
+}
+
+
 // Public fumember functions
 void LLHConverter::convertDeg2XYZ(const double& lat_deg, const double& lon_deg, const double& h, double& x, double& y,
                                   double& z, const LLHParam& param)


### PR DESCRIPTION
Geoid models can now be set in the constructor of llh_constructer.

@Tomoya-Sato 
I would appreciate confirmation of this, just to be sure.