### PR TITLE
Fix build warnings(ROS2)

### DIFF
--- a/src/height_converter.cpp
+++ b/src/height_converter.cpp
@@ -69,6 +69,8 @@ double HeightConverter::getGeoidDeg(const double& lat_deg, const double& lon_deg
       return getGeoidEGM2008(lat_deg, lon_deg);
     case GeoidType::GSIGEO2011:
       return getGeoidGSIGEO2011(lat_deg, lon_deg);
+    default:
+      throw std::invalid_argument("Invalid geoid type");
   }
 }
 


### PR DESCRIPTION
The following warnings should not appear.
```
--- stderr: llh_converter                              
/home/autoware/eagleye_ros2_ws/src/llh_converter/src/height_converter.cpp: In member function ‘double llh_converter::HeightConverter::getGeoidDeg(const double&, const double&)’:
/home/autoware/eagleye_ros2_ws/src/llh_converter/src/height_converter.cpp:73:1: warning: control reaches end of non-void function [-Wreturn-type]
   73 | }
      | ^
---
Finished <<< llh_converter [1.93s]
```