### PR TITLE
[fix] enum order

### DIFF
--- a/include/llh_converter/llh_converter.hpp
+++ b/include/llh_converter/llh_converter.hpp
@@ -56,8 +56,8 @@ enum class MGRSPrecision
 enum class ProjectionMethod
 {
   TM = 0,
-  JPRCS = 1,
-  MGRS = 2,
+  MGRS = 1,
+  JPRCS = 2,
 };
 
 struct TMParam


### PR DESCRIPTION
## Description

Fixed an issue where the order of the `ProjectionMethod` enum was unintentionally incorrect.