### PR TITLE
fix: remove single arg geoid file load for JPGEO2024

### DIFF
--- a/include/llh_converter/height_converter.hpp
+++ b/include/llh_converter/height_converter.hpp
@@ -68,7 +68,7 @@ public:
   double getGeoidDeg(const double& lat_deg, const double& lon_deg);
   void loadGSIGEOGeoidFile(const std::string& geoid_file);
   void loadGSIGEOGeoidFile();
-  void loadJPGEO2024GeoidFile(const std::string& geoid_file);
+  void loadJPGEO2024GeoidFile(const std::string& geoid_file, const std::string& hrefconv_file);
   void loadJPGEO2024GeoidFile();
 
 private:

--- a/src/height_converter.cpp
+++ b/src/height_converter.cpp
@@ -105,9 +105,9 @@ void HeightConverter::loadGSIGEOGeoidFile()
   gsigeo2011_.loadGeoidMap("/usr/share/GSIGEO/gsigeo2011_ver2_1.asc");
 }
 
-void HeightConverter::loadJPGEO2024GeoidFile(const std::string& geoid_file)
+void HeightConverter::loadJPGEO2024GeoidFile(const std::string& geoid_file, const std::string& hrefconv_file)
 {
-  jpgeo2024_.loadGeoidMap(geoid_file);
+  jpgeo2024_.loadGeoidMap(geoid_file, hrefconv_file);
 }
 
 void HeightConverter::loadJPGEO2024GeoidFile()


### PR DESCRIPTION
# Description

Update geoid model loading for JPGEO2024 in `HeightConverter`