### PR TITLE
feat: support ROS 2 Jazzy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,6 @@ ament_auto_add_library(llh_converter SHARED
 
 target_link_libraries(llh_converter PUBLIC ${catkin_LIBRARIES} ${GeographicLib_LIBRARIES})
 
-ament_auto_find_build_dependencies()
-
 install(TARGETS llh_converter
   INCLUDES DESTINATION include
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,13 +11,12 @@ endif()
 
 find_package(ament_cmake_auto REQUIRED)
 
+# GeographicLib
 find_package(PkgConfig)
-find_path(GeographicLib INCLUDE_DIR GeographicLib/config.h
+find_path(GeographicLib_INCLUDE_DIR GeographicLib/Config.h
   PATH_SUFFIXES GeographicLib
 )
-set(GeographicLib_LIBRARIES
-  NAMES Geographic
-)
+find_library(GeographicLib_LIBRARIES NAMES Geographic GeographicLib)
 
 ament_auto_find_build_dependencies()
 
@@ -40,7 +39,7 @@ ament_auto_add_library(llh_converter SHARED
   include/llh_converter/meridian_convergence_angle_correction.hpp
 )
 
-target_link_libraries(llh_converter PUBLIC ${catkin_LIBRARIES} Geographic)
+target_link_libraries(llh_converter PUBLIC ${catkin_LIBRARIES} ${GeographicLib_LIBRARIES})
 
 ament_auto_find_build_dependencies()
 


### PR DESCRIPTION
## Background
The name of the geographiclib library file installed under `/usr/lib/x86_64-linux-gnu/` changed from `libGeographic.so` to `libGeographicLib.so` in Ubuntu 24.04. This causes the build failure in Ubuntu 24.04. 

Similar fix was made in https://github.com/MapIV/llh_converter/pull/23/files for ROS 1, but find_package(GeographicLib) failes for some reasons in colcon build so I'm applying a different work around for ROS 2 branch.

## Proposed Solution
The PR would add a search name path to look for both of the library names to support build in Ubuntu 24.04 while keeping compatibility for Ubuntu 22.04. 

## How the PR was tested
I have confirmed that it builds fine in both Ubuntu 22.04(ROS 2 Humble) and Ubuntu 24.04 (ROS 2 Jazzy)
