### PR TITLE
feat: add orthometric_height_offset support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,10 @@ add_executable(jpgeo2024_test test/jpgeo2024_test.cpp)
 target_link_libraries(jpgeo2024_test ${catkin_LIBRARIES} llh_converter)
 add_dependencies(jpgeo2024_test ${catkin_EXPORTED_TARGETS})
 
+add_executable(height_offset_test test/height_offset_test.cpp)
+target_link_libraries(height_offset_test ${catkin_LIBRARIES} llh_converter)
+add_dependencies(height_offset_test ${catkin_EXPORTED_TARGETS})
+
 install(DIRECTORY include/llh_converter/
   DESTINATION include/llh_converter
   FILES_MATCHING PATTERN "*.hpp"

--- a/include/llh_converter/llh_converter.hpp
+++ b/include/llh_converter/llh_converter.hpp
@@ -77,6 +77,7 @@ struct LLHParam
   ConvertType height_convert_type;
   GeoidType geoid_type;
   TMParam tm_param;
+  double vertical_datum_offset = 0.0;  // Offset from T.P. in meters
 };
 
 class LLHConverter

--- a/include/llh_converter/llh_converter.hpp
+++ b/include/llh_converter/llh_converter.hpp
@@ -77,7 +77,7 @@ struct LLHParam
   ConvertType height_convert_type;
   GeoidType geoid_type;
   TMParam tm_param;
-  double height_offset = 0.0;  // Offset from T.P. in meters (T.P.からの高さオフセット[m])
+  double orthometric_height_offset = 0.0;  // Offset from T.P. in meters (T.P.からの高さオフセット[m])
 };
 
 class LLHConverter

--- a/include/llh_converter/llh_converter.hpp
+++ b/include/llh_converter/llh_converter.hpp
@@ -77,7 +77,7 @@ struct LLHParam
   ConvertType height_convert_type;
   GeoidType geoid_type;
   TMParam tm_param;
-  double vertical_datum_offset = 0.0;  // Offset from T.P. in meters
+  double height_offset = 0.0;  // Offset from T.P. in meters (T.P.からの高さオフセット[m])
 };
 
 class LLHConverter

--- a/include/llh_converter/llh_converter.hpp
+++ b/include/llh_converter/llh_converter.hpp
@@ -77,7 +77,7 @@ struct LLHParam
   ConvertType height_convert_type;
   GeoidType geoid_type;
   TMParam tm_param;
-  double orthometric_height_offset = 0.0;  // Offset from T.P. in meters (T.P.からの高さオフセット[m])
+  double orthometric_height_offset = 0.0;  // Offset from T.P. in meters
 };
 
 class LLHConverter

--- a/src/llh_converter.cpp
+++ b/src/llh_converter.cpp
@@ -98,14 +98,10 @@ void LLHConverter::convertRad2XYZ(const double& lat_rad, const double& lon_rad, 
   height_converter_.setGeoidType(param.geoid_type);
   z = height_converter_.convertHeightRad(lat_rad, lon_rad, h, param.height_convert_type);
 
-  // Apply vertical datum correction (bidirectional)
+  // Apply height offset correction (ORTHO時のみ)
   if (param.height_convert_type == ConvertType::ELLIPS2ORTHO)
   {
-    z += param.vertical_datum_offset;  // Forward: T.P. + offset = vertical datum height
-  }
-  else if (param.height_convert_type == ConvertType::ORTHO2ELLIPS)
-  {
-    z -= param.vertical_datum_offset;  // Reverse: vertical datum height - offset = T.P.
+    z += param.height_offset;  // T.P. + offset = final height
   }
 }
 

--- a/src/llh_converter.cpp
+++ b/src/llh_converter.cpp
@@ -98,7 +98,7 @@ void LLHConverter::convertRad2XYZ(const double& lat_rad, const double& lon_rad, 
   height_converter_.setGeoidType(param.geoid_type);
   z = height_converter_.convertHeightRad(lat_rad, lon_rad, h, param.height_convert_type);
 
-  // Apply height offset correction (ORTHO時のみ)
+  // Apply height offset correction (only for orthometric height)
   if (param.height_convert_type == ConvertType::ELLIPS2ORTHO)
   {
     z += param.orthometric_height_offset;  // T.P. + offset = final height

--- a/src/llh_converter.cpp
+++ b/src/llh_converter.cpp
@@ -101,7 +101,7 @@ void LLHConverter::convertRad2XYZ(const double& lat_rad, const double& lon_rad, 
   // Apply height offset correction (ORTHO時のみ)
   if (param.height_convert_type == ConvertType::ELLIPS2ORTHO)
   {
-    z += param.height_offset;  // T.P. + offset = final height
+    z += param.orthometric_height_offset;  // T.P. + offset = final height
   }
 }
 

--- a/src/llh_converter.cpp
+++ b/src/llh_converter.cpp
@@ -97,6 +97,16 @@ void LLHConverter::convertRad2XYZ(const double& lat_rad, const double& lon_rad, 
   // Convert h to z
   height_converter_.setGeoidType(param.geoid_type);
   z = height_converter_.convertHeightRad(lat_rad, lon_rad, h, param.height_convert_type);
+
+  // Apply vertical datum correction (bidirectional)
+  if (param.height_convert_type == ConvertType::ELLIPS2ORTHO)
+  {
+    z += param.vertical_datum_offset;  // Forward: T.P. + offset = vertical datum height
+  }
+  else if (param.height_convert_type == ConvertType::ORTHO2ELLIPS)
+  {
+    z -= param.vertical_datum_offset;  // Reverse: vertical datum height - offset = T.P.
+  }
 }
 
 void LLHConverter::revertXYZ2Deg(const double& x, const double& y, double& lat_deg, double& lon_deg,

--- a/test/height_offset_test.cpp
+++ b/test/height_offset_test.cpp
@@ -70,7 +70,7 @@ int main()
     param_no_offset.grid_code = "7";
     param_no_offset.height_convert_type = llh_converter::ConvertType::ELLIPS2ORTHO;
     param_no_offset.geoid_type = llh_converter::GeoidType::JPGEO2024;
-    param_no_offset.height_offset = 0.0;  // Default value
+    param_no_offset.orthometric_height_offset = 0.0;  // Default value
 
     double lat_deg = 35.6895;
     double lon_deg = 139.6917;
@@ -94,10 +94,10 @@ int main()
     param_no_offset.grid_code = "7";
     param_no_offset.height_convert_type = llh_converter::ConvertType::ELLIPS2ORTHO;
     param_no_offset.geoid_type = llh_converter::GeoidType::JPGEO2024;
-    param_no_offset.height_offset = 0.0;
+    param_no_offset.orthometric_height_offset = 0.0;
 
     llh_converter::LLHParam param_with_offset = param_no_offset;
-    param_with_offset.height_offset = -1.134;  // A.P. offset from T.P.
+    param_with_offset.orthometric_height_offset = -1.134;  // A.P. offset from T.P.
 
     double lat_deg = 35.6895;
     double lon_deg = 139.6917;
@@ -129,10 +129,10 @@ int main()
     param_tp.grid_code = "7";
     param_tp.height_convert_type = llh_converter::ConvertType::ELLIPS2ORTHO;
     param_tp.geoid_type = llh_converter::GeoidType::JPGEO2024;
-    param_tp.height_offset = 0.0;
+    param_tp.orthometric_height_offset = 0.0;
 
     llh_converter::LLHParam param_positive = param_tp;
-    param_positive.height_offset = 2.0;
+    param_positive.orthometric_height_offset = 2.0;
 
     double lat_deg = 35.6895;
     double lon_deg = 139.6917;
@@ -162,10 +162,10 @@ int main()
     param_tp.grid_code = "7";
     param_tp.height_convert_type = llh_converter::ConvertType::ELLIPS2ORTHO;
     param_tp.geoid_type = llh_converter::GeoidType::JPGEO2024;
-    param_tp.height_offset = 0.0;
+    param_tp.orthometric_height_offset = 0.0;
 
     llh_converter::LLHParam param_yp = param_tp;
-    param_yp.height_offset = -1.09;  // Y.P. offset from T.P.
+    param_yp.orthometric_height_offset = -1.09;  // Y.P. offset from T.P.
 
     double lat_deg = 35.4437;
     double lon_deg = 139.6452;
@@ -195,7 +195,7 @@ int main()
     param_ellips.grid_code = "7";
     param_ellips.height_convert_type = llh_converter::ConvertType::NONE;  // ELLIPS
     param_ellips.geoid_type = llh_converter::GeoidType::JPGEO2024;
-    param_ellips.height_offset = -1.134;
+    param_ellips.orthometric_height_offset = -1.134;
 
     double lat_deg = 35.6895;
     double lon_deg = 139.6917;

--- a/test/height_offset_test.cpp
+++ b/test/height_offset_test.cpp
@@ -1,0 +1,217 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2024, Map IV, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file height_offset_test.cpp
+ * @brief Test for height offset functionality in coordinate conversion
+ * @test Verify that height_offset is correctly applied during coordinate transformation
+ */
+
+#include "llh_converter/llh_converter.hpp"
+#include <iostream>
+#include <iomanip>
+#include <cmath>
+
+// Utility function to compare floating-point values with tolerance
+void testHeightOffset(const double& result, const double& expected, const std::string& test_name)
+{
+  const double tolerance = 1e-4;  // 0.1mm tolerance
+  if (std::abs(result - expected) < tolerance)
+  {
+    std::cout << "\033[32;1m✓ PASS: " << test_name << " (result: " << std::fixed << std::setprecision(6)
+              << result << " == expected: " << expected << ")\033[m" << std::endl;
+  }
+  else
+  {
+    std::cout << "\033[31;1m✗ FAIL: " << test_name << " (result: " << std::fixed << std::setprecision(6)
+              << result << " != expected: " << expected << ", diff: " << (result - expected) << ")\033[m"
+              << std::endl;
+  }
+}
+
+int main()
+{
+  std::cout << "=== Height Offset Test ===" << std::endl << std::endl;
+
+  // Test 1: Default behavior (no height offset)
+  {
+    std::cout << "Test 1: Default height_offset = 0.0 (No correction)" << std::endl;
+
+    llh_converter::LLHConverter converter;
+    llh_converter::LLHParam param_no_offset;
+    param_no_offset.projection_method = llh_converter::ProjectionMethod::JPRCS;
+    param_no_offset.grid_code = "7";
+    param_no_offset.height_convert_type = llh_converter::ConvertType::ELLIPS2ORTHO;
+    param_no_offset.geoid_type = llh_converter::GeoidType::JPGEO2024;
+    param_no_offset.height_offset = 0.0;  // Default value
+
+    double lat_deg = 35.6895;
+    double lon_deg = 139.6917;
+    double ellips_height = 10.0;
+
+    double x, y, z;
+    converter.convertDeg2XYZ(lat_deg, lon_deg, ellips_height, x, y, z, param_no_offset);
+
+    std::cout << "  Input: lat=" << lat_deg << "°, lon=" << lon_deg << "°, h=" << ellips_height << "m" << std::endl;
+    std::cout << "  Output (no offset): X=" << x << ", Y=" << y << ", Z=" << z << std::endl;
+    std::cout << std::endl;
+  }
+
+  // Test 2: Arakawa Peil (A.P.) correction
+  {
+    std::cout << "Test 2: Arakawa Peil (A.P.) height_offset = -1.134 m" << std::endl;
+
+    llh_converter::LLHConverter converter;
+    llh_converter::LLHParam param_no_offset;
+    param_no_offset.projection_method = llh_converter::ProjectionMethod::JPRCS;
+    param_no_offset.grid_code = "7";
+    param_no_offset.height_convert_type = llh_converter::ConvertType::ELLIPS2ORTHO;
+    param_no_offset.geoid_type = llh_converter::GeoidType::JPGEO2024;
+    param_no_offset.height_offset = 0.0;
+
+    llh_converter::LLHParam param_with_offset = param_no_offset;
+    param_with_offset.height_offset = -1.134;  // A.P. offset from T.P.
+
+    double lat_deg = 35.6895;
+    double lon_deg = 139.6917;
+    double ellips_height = 10.0;
+
+    double x1, y1, z1;
+    converter.convertDeg2XYZ(lat_deg, lon_deg, ellips_height, x1, y1, z1, param_no_offset);
+
+    double x2, y2, z2;
+    converter.convertDeg2XYZ(lat_deg, lon_deg, ellips_height, x2, y2, z2, param_with_offset);
+
+    std::cout << "  Input: lat=" << lat_deg << "°, lon=" << lon_deg << "°, h=" << ellips_height << "m" << std::endl;
+    std::cout << "  T.P. Output:  Z=" << std::fixed << std::setprecision(4) << z1 << "m" << std::endl;
+    std::cout << "  A.P. Output:  Z=" << std::fixed << std::setprecision(4) << z2 << "m" << std::endl;
+    std::cout << "  Expected diff: -1.134m" << std::endl;
+    std::cout << "  Actual diff:   " << (z2 - z1) << "m" << std::endl;
+
+    testHeightOffset(z2 - z1, -1.134, "A.P. offset difference");
+    std::cout << std::endl;
+  }
+
+  // Test 3: Positive offset (rare but valid case)
+  {
+    std::cout << "Test 3: Positive offset = 2.0 m (hypothetical datum higher than T.P.)" << std::endl;
+
+    llh_converter::LLHConverter converter;
+    llh_converter::LLHParam param_tp;
+    param_tp.projection_method = llh_converter::ProjectionMethod::JPRCS;
+    param_tp.grid_code = "7";
+    param_tp.height_convert_type = llh_converter::ConvertType::ELLIPS2ORTHO;
+    param_tp.geoid_type = llh_converter::GeoidType::JPGEO2024;
+    param_tp.height_offset = 0.0;
+
+    llh_converter::LLHParam param_positive = param_tp;
+    param_positive.height_offset = 2.0;
+
+    double lat_deg = 35.6895;
+    double lon_deg = 139.6917;
+    double ellips_height = 10.0;
+
+    double x1, y1, z1;
+    converter.convertDeg2XYZ(lat_deg, lon_deg, ellips_height, x1, y1, z1, param_tp);
+
+    double x2, y2, z2;
+    converter.convertDeg2XYZ(lat_deg, lon_deg, ellips_height, x2, y2, z2, param_positive);
+
+    std::cout << "  Input: lat=" << lat_deg << "°, lon=" << lon_deg << "°, h=" << ellips_height << "m" << std::endl;
+    std::cout << "  T.P. Output:          Z=" << std::fixed << std::setprecision(4) << z1 << "m" << std::endl;
+    std::cout << "  Positive +2.0 Output: Z=" << std::fixed << std::setprecision(4) << z2 << "m" << std::endl;
+
+    testHeightOffset(z2 - z1, 2.0, "Positive offset difference");
+    std::cout << std::endl;
+  }
+
+  // Test 4: Yokohama Port (Y.P.) offset
+  {
+    std::cout << "Test 4: Yokohama Port (Y.P.) height_offset = -1.09 m" << std::endl;
+
+    llh_converter::LLHConverter converter;
+    llh_converter::LLHParam param_tp;
+    param_tp.projection_method = llh_converter::ProjectionMethod::JPRCS;
+    param_tp.grid_code = "7";
+    param_tp.height_convert_type = llh_converter::ConvertType::ELLIPS2ORTHO;
+    param_tp.geoid_type = llh_converter::GeoidType::JPGEO2024;
+    param_tp.height_offset = 0.0;
+
+    llh_converter::LLHParam param_yp = param_tp;
+    param_yp.height_offset = -1.09;  // Y.P. offset from T.P.
+
+    double lat_deg = 35.4437;
+    double lon_deg = 139.6452;
+    double ellips_height = 5.0;
+
+    double x1, y1, z1;
+    converter.convertDeg2XYZ(lat_deg, lon_deg, ellips_height, x1, y1, z1, param_tp);
+
+    double x2, y2, z2;
+    converter.convertDeg2XYZ(lat_deg, lon_deg, ellips_height, x2, y2, z2, param_yp);
+
+    std::cout << "  Input: lat=" << lat_deg << "°, lon=" << lon_deg << "°, h=" << ellips_height << "m" << std::endl;
+    std::cout << "  T.P. Output: Z=" << std::fixed << std::setprecision(4) << z1 << "m" << std::endl;
+    std::cout << "  Y.P. Output: Z=" << std::fixed << std::setprecision(4) << z2 << "m" << std::endl;
+
+    testHeightOffset(z2 - z1, -1.09, "Y.P. offset difference");
+    std::cout << std::endl;
+  }
+
+  // Test 5: ELLIPS height type should NOT apply offset
+  {
+    std::cout << "Test 5: ELLIPS height type (offset should NOT be applied)" << std::endl;
+
+    llh_converter::LLHConverter converter;
+    llh_converter::LLHParam param_ellips;
+    param_ellips.projection_method = llh_converter::ProjectionMethod::JPRCS;
+    param_ellips.grid_code = "7";
+    param_ellips.height_convert_type = llh_converter::ConvertType::NONE;  // ELLIPS
+    param_ellips.geoid_type = llh_converter::GeoidType::JPGEO2024;
+    param_ellips.height_offset = -1.134;
+
+    double lat_deg = 35.6895;
+    double lon_deg = 139.6917;
+    double ellips_height = 10.0;
+
+    double x, y, z;
+    converter.convertDeg2XYZ(lat_deg, lon_deg, ellips_height, x, y, z, param_ellips);
+
+    std::cout << "  Input: lat=" << lat_deg << "°, lon=" << lon_deg << "°, h=" << ellips_height << "m" << std::endl;
+    std::cout << "  Height type: ELLIPS (offset=-1.134 should be ignored)" << std::endl;
+    std::cout << "  Output Z: " << std::fixed << std::setprecision(6) << z << "m" << std::endl;
+    std::cout << "  Note: For ELLIPS type, output should match ellipsoidal height (no geoid or offset correction)"
+              << std::endl;
+    std::cout << std::endl;
+  }
+
+  std::cout << "=== All tests completed ===" << std::endl;
+  return 0;
+}


### PR DESCRIPTION
## Summary

正標高変換時に高さオフセットを適用する機能を追加。荒川工事基準面（A.P.）等の工事基準面に対応。

## Changes

- `llh_converter.hpp`: `LLHParam` 構造体に `orthometric_height_offset` フィールド追加（デフォルト: 0.0）
- `llh_converter.cpp`: `convertRad2XYZ()` で ELLIPS2ORTHO 時のみオフセット適用
- `height_offset_test.cpp`: テストスイート追加

## Usage

```cpp
llh_converter::LLHParam param;
param.orthometric_height_offset = -1.134;  // A.P. = T.P. - 1.134m
```

## Test plan

- [x] デフォルト値（0.0）で従来動作維持
- [x] A.P.オフセット（-1.134m）正常適用
- [x] 楕円体高モードではオフセット無視