### PR TITLE
fix: export geographiclib headers for downstream builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: build
-on: pull_request
+on:
+  pull_request:
+  push:
 
 jobs:
   jazzy_build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: build
+on: pull_request
+
+jobs:
+  jazzy_build:
+    runs-on: ubuntu-24.04
+
+    container: ros:jazzy
+    services:
+      ros:
+        image: ros
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: rosdep update
+        run: |
+          apt-get update
+          rosdep update
+      - name: Create Workspace
+        run: |
+          mkdir -p ~/ros2_ws/src/
+          cp -r "$(pwd)" ~/ros2_ws/src/
+      - name: Install GeographicLib
+        run: |
+          apt-get install -y libgeographiclib-dev geographiclib-tools geographiclib-doc
+      - name: Build
+        run: |
+          cd ~/ros2_ws/
+          source /opt/ros/jazzy/setup.bash
+          rosdep install --from-paths src --ignore-src -r -y
+          colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --catkin-skip-building-tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,5 @@
 name: build
-on:
-  pull_request:
-  push:
+on: pull_request
 
 jobs:
   jazzy_build:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ ament_auto_find_build_dependencies()
 
 include_directories(
   include
-  ${GeographicLib_INCLUDE_DIRS}
+  ${GeographicLib_INCLUDE_DIR}
 )
 link_directories(
   /usr/local/lib
@@ -53,11 +53,12 @@ install(TARGETS llh_converter
 
 target_include_directories(llh_converter
   PUBLIC
+    ${GeographicLib_INCLUDE_DIR}
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
 
-ament_export_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+ament_export_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include ${GeographicLib_INCLUDE_DIR})
 
 ament_export_libraries(llh_converter)
 


### PR DESCRIPTION
## Summary

- export GeographicLib include paths so downstream packages can compile headers that include `GeographicLib/Geoid.hpp`
- keep downstream builds working when `llh_converter` public headers are consumed directly

## Details

- use `GeographicLib_INCLUDE_DIR` consistently
- add the GeographicLib include path to the exported include directories

## Validation

- `colcon build --packages-select llh_converter --cmake-args -DCMAKE_BUILD_TYPE=Release`
- downstream `gnss_compass` build no longer fails on missing `GeographicLib/Geoid.hpp`
