### PR TITLE
[fix] handle geoid errors with exceptions

### DIFF
--- a/src/gsigeo.cpp
+++ b/src/gsigeo.cpp
@@ -35,11 +35,20 @@
 #include <sstream>
 #include <cmath>
 #include <iomanip>
+#include <stdexcept>
 
 #include <boost/algorithm/string.hpp>
 
 namespace llh_converter
 {
+namespace
+{
+[[noreturn]] void throwGeoidError(const std::string& message)
+{
+  throw std::runtime_error(message);
+}
+}  // namespace
+
 std::vector<std::string> split(std::string input, char delimiter)
 {
   std::istringstream stream(input);
@@ -67,8 +76,7 @@ void GSIGEO2011::loadGeoidMap(const std::string& geoid_file)
   std::ifstream ifs(geoid_file);
   if (!ifs)
   {
-    std::cerr << "Error: Cannot open Geoid data file: " << geoid_file << std::endl;
-    exit(2);
+    throwGeoidError("Error: Cannot open Geoid data file: " + geoid_file);
   }
 
   geoid_map_.resize(row_size_);
@@ -105,8 +113,7 @@ double GSIGEO2011::getGeoid(const double& lat, const double& lon)
 {
   if (!is_geoid_loaded_)
   {
-    std::cerr << "Error: Geoid map is not loaded" << std::endl;
-    exit(1);
+    throwGeoidError("Error: Geoid map is not loaded");
   }
   const double lat_min = 20;
   const double lon_min = 120;
@@ -125,16 +132,15 @@ double GSIGEO2011::getGeoid(const double& lat, const double& lon)
 
   if (i_lat < 0 || i_lat >= row_size_ - 1 || i_lon < 0 || i_lon >= column_size_ - 1)
   {
-    std::cerr << "Error: latitude/longitude is out of range (20~50, 120~150)" << std::endl;
-    std::cerr << (lat, lon) << std::endl;
-    exit(1);
+    std::ostringstream oss;
+    oss << "Error: latitude/longitude is out of range (20~50, 120~150): " << lat << ", " << lon;
+    throwGeoidError(oss.str());
   }
 
   if (geoid_map_[i_lat][i_lon] == 999 || geoid_map_[i_lat][j_lon] == 999 || geoid_map_[j_lat][i_lon] == 999 ||
       geoid_map_[j_lat][j_lon] == 999)
   {
-    std::cerr << "Error: Not supported area" << std::endl;
-    exit(1);
+    throwGeoidError("Error: Not supported area");
   }
 
   double geoid = (1 - t) * (1 - u) * geoid_map_[i_lat][i_lon] + (1 - t) * u * geoid_map_[i_lat][j_lon] +

--- a/src/height_converter.cpp
+++ b/src/height_converter.cpp
@@ -31,6 +31,7 @@
 #include "llh_converter/height_converter.hpp"
 
 #include <iostream>
+#include <stdexcept>
 
 namespace llh_converter
 {
@@ -92,7 +93,11 @@ double HeightConverter::getGeoidDeg(const double& lat_deg, const double& lon_deg
       return getGeoidGSIGEO2011(lat_deg, lon_deg);
     case GeoidType::JPGEO2024:
       return getGeoidJPGEO2024(lat_deg, lon_deg);
+    case GeoidType::NONE:
+      return 0.0;
   }
+
+  throw std::runtime_error("Error: Unsupported geoid type");
 }
 
 void HeightConverter::loadGSIGEOGeoidFile(const std::string& geoid_file)
@@ -123,8 +128,7 @@ double HeightConverter::getGeoidEGM2008(const double& lat_deg, const double& lon
   }
   catch (const GeographicLib::GeographicErr& e)
   {
-    std::cerr << "GeographicLib Error: " << e.what() << std::endl;
-    exit(EXIT_FAILURE);
+    throw std::runtime_error("GeographicLib Error: " + std::string(e.what()));
   }
 }
 

--- a/src/jpgeo2024.cpp
+++ b/src/jpgeo2024.cpp
@@ -154,7 +154,7 @@ double JPGEO2024::getGeoid(const double& lat, const double& lon)
   if (lat < 15.0 || lat > 50.0 || lon < 120.0 || lon > 160.0)
   {
     std::ostringstream oss;
-    oss << "Input coordinates out of range: " << lat << ", " << lon;
+    oss << "Error: latitude/longitude is out of range (15~50, 120~160): " << lat << ", " << lon;
     throwGeoidError(oss.str());
   }
 
@@ -171,7 +171,9 @@ double JPGEO2024::getGeoid(const double& lat, const double& lon)
 
   if (i1 < 0 || i2 >= row_size_ || j1 < 0 || j2 >= column_size_)
   {
-    throwGeoidError("Input coordinates are outside the JPGEO2024 grid.");
+    std::ostringstream oss;
+    oss << "Error: latitude/longitude is outside the JPGEO2024 grid: " << lat << ", " << lon;
+    throwGeoidError(oss.str());
   }
 
   // Geoid height at the four corners
@@ -182,7 +184,9 @@ double JPGEO2024::getGeoid(const double& lat, const double& lon)
 
   if (f00 == -9999.0 || f10 == -9999.0 || f01 == -9999.0 || f11 == -9999.0)
   {
-    throwGeoidError("Error: Not supported area");
+    std::ostringstream oss;
+    oss << "Error: Not supported area at coordinates: " << lat << ", " << lon;
+    throwGeoidError(oss.str());
   }
 
   // Coordinates of the four corners

--- a/src/jpgeo2024.cpp
+++ b/src/jpgeo2024.cpp
@@ -35,10 +35,19 @@
 #include <sstream>
 #include <cmath>
 #include <iomanip>
+#include <stdexcept>
 
 #include <boost/algorithm/string.hpp>
 namespace llh_converter
 {
+namespace
+{
+[[noreturn]] void throwGeoidError(const std::string& message)
+{
+  throw std::runtime_error(message);
+}
+}  // namespace
+
 JPGEO2024::JPGEO2024()
 {
 }
@@ -52,8 +61,7 @@ void JPGEO2024::loadGeoidMap(const std::string& geoid_file)
   std::ifstream infile(geoid_file);
   if (!infile)
   {
-    std::cerr << "Error opening file: " << geoid_file << std::endl;
-    return;
+    throwGeoidError("Error opening file: " + geoid_file);
   }
 
   std::string line;
@@ -69,8 +77,7 @@ void JPGEO2024::loadGeoidMap(const std::string& geoid_file)
 
   if (!header_end)
   {
-    std::cerr << "Header not properly formatted in file." << std::endl;
-    return;
+    throwGeoidError("Header not properly formatted in file.");
   }
 
   geoid_map_.resize(row_size_, std::vector<double>(column_size_, -9999.0));
@@ -81,8 +88,9 @@ void JPGEO2024::loadGeoidMap(const std::string& geoid_file)
     {
       if (!(infile >> geoid_map_[i][j]))
       {
-        std::cerr << "Error reading geoid data at row " << i << ", col " << j << std::endl;
-        return;
+        std::ostringstream oss;
+        oss << "Error reading geoid data at row " << i << ", col " << j;
+        throwGeoidError(oss.str());
       }
     }
   }
@@ -97,8 +105,7 @@ void JPGEO2024::loadGeoidMap(const std::string& geoid_file, const std::string& h
   std::ifstream infile(hrefconv_file);
   if (!infile)
   {
-    std::cerr << "Error opening file: " << hrefconv_file << std::endl;
-    return;
+    throwGeoidError("Error opening file: " + hrefconv_file);
   }
 
   std::string line;
@@ -114,8 +121,7 @@ void JPGEO2024::loadGeoidMap(const std::string& geoid_file, const std::string& h
 
   if (!header_end)
   {
-    std::cerr << "Header not properly formatted in file." << std::endl;
-    return;
+    throwGeoidError("Header not properly formatted in file.");
   }
 
   for (int i = 0; i < row_size_; ++i)
@@ -125,8 +131,9 @@ void JPGEO2024::loadGeoidMap(const std::string& geoid_file, const std::string& h
       double tmp;
       if (!(infile >> tmp))
       {
-        std::cerr << "Error reading geoid data at row " << i << ", col " << j << std::endl;
-        return;
+        std::ostringstream oss;
+        oss << "Error reading geoid data at row " << i << ", col " << j;
+        throwGeoidError(oss.str());
       }
 
       if (tmp > -9998.0)
@@ -141,14 +148,14 @@ double JPGEO2024::getGeoid(const double& lat, const double& lon)
 {
   if (!is_geoid_loaded_)
   {
-    std::cerr << "Geoid map not loaded." << std::endl;
-    return std::numeric_limits<double>::quiet_NaN();
+    throwGeoidError("Geoid map not loaded.");
   }
 
   if (lat < 15.0 || lat > 50.0 || lon < 120.0 || lon > 160.0)
   {
-    std::cerr << "Input coordinates out of range." << std::endl;
-    return std::numeric_limits<double>::quiet_NaN();
+    std::ostringstream oss;
+    oss << "Input coordinates out of range: " << lat << ", " << lon;
+    throwGeoidError(oss.str());
   }
 
   // Grid step (latitude 1 minute = 0.0166667 degrees, longitude 1.5 minutes = 0.025 degrees)
@@ -164,7 +171,7 @@ double JPGEO2024::getGeoid(const double& lat, const double& lon)
 
   if (i1 < 0 || i2 >= row_size_ || j1 < 0 || j2 >= column_size_)
   {
-    return std::numeric_limits<double>::quiet_NaN();
+    throwGeoidError("Input coordinates are outside the JPGEO2024 grid.");
   }
 
   // Geoid height at the four corners
@@ -175,7 +182,7 @@ double JPGEO2024::getGeoid(const double& lat, const double& lon)
 
   if (f00 == -9999.0 || f10 == -9999.0 || f01 == -9999.0 || f11 == -9999.0)
   {
-    return std::numeric_limits<double>::quiet_NaN();
+    throwGeoidError("Error: Not supported area");
   }
 
   // Coordinates of the four corners

--- a/test/height_converter_test.cpp
+++ b/test/height_converter_test.cpp
@@ -33,6 +33,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include <functional>
 
 void test(const double& result, const double& answer)
 {
@@ -69,6 +70,21 @@ void test2(const double result0, const double result1, const double answer0, con
 int main(int argc, char** argv)
 {
   llh_converter::HeightConverter hc;
+  bool has_failure = false;
+
+  auto test_throw = [&](const std::string& label, const std::function<void()>& func) {
+    std::cout << label;
+    try
+    {
+      func();
+      std::cout << "\033[31;1mTEST FAILED : expected exception\033[m" << std::endl;
+      has_failure = true;
+    }
+    catch (const std::exception& e)
+    {
+      std::cout << "\033[32;1mTEST SUCCESS: " << e.what() << "\033[m" << std::endl;
+    }
+  };
 
   // GSIGEO Test
   std::cout << "GSIGEO2011 Test" << std::endl;
@@ -115,6 +131,12 @@ int main(int argc, char** argv)
   std::cout << "Testing (" << std::setw(9) << 35.160410 << ", " << std::setw(9) << 139.615526 << ") ... ";
   test(hc.getGeoidDeg(35.160410, 139.615526), 36.7568);
 
+  std::cout << "Out of range geoid error test" << std::endl;
+  hc.setGeoidType(llh_converter::GeoidType::GSIGEO2011);
+  test_throw("Testing GSIGEO2011 out of range ... ", [&]() { hc.getGeoidDeg(35.0, 100.0); });
+  hc.setGeoidType(llh_converter::GeoidType::JPGEO2024);
+  test_throw("Testing JPGEO2024 out of range ... ", [&]() { hc.getGeoidDeg(35.0, 100.0); });
+
   // LLHConverter test
   std::cout << "LLHConverter Test" << std::endl;
   llh_converter::LLHConverter llh_converter;
@@ -122,10 +144,24 @@ int main(int argc, char** argv)
   param.projection_method = llh_converter::ProjectionMethod::MGRS;
   param.height_convert_type = llh_converter::ConvertType::NONE;
   param.geoid_type = llh_converter::GeoidType::EGM2008;
+  param.tm_param.inv_flatten_ratio = 298.257222101;
+  param.tm_param.semi_major_axis = 6378137.0;
+  param.tm_param.scale_factor = 0.9996;
+  param.tm_param.origin_lat_rad = 35.5 * M_PI / 180.;
+  param.tm_param.origin_lon_rad = 135.5 * M_PI / 180.;
 
   double test_lat = 35.5, test_lon = 135.5;
+  double overseas_lat = 37.7749, overseas_lon = -122.4194;
 
   double x, y, z;
+  llh_converter::LLHParam tm_param = param;
+  tm_param.projection_method = llh_converter::ProjectionMethod::TM;
+  tm_param.geoid_type = llh_converter::GeoidType::JPGEO2024;
+  test_throw("Testing LLHConverter JPGEO2024 out of range ... ",
+             [&]() { llh_converter.convertDeg2XYZ(overseas_lat, overseas_lon, 50, x, y, z, tm_param); });
+  tm_param.geoid_type = llh_converter::GeoidType::GSIGEO2011;
+  test_throw("Testing LLHConverter GSIGEO2011 out of range ... ",
+             [&]() { llh_converter.convertDeg2XYZ(overseas_lat, overseas_lon, 50, x, y, z, tm_param); });
   std::cout << "Testing MGRS  ... ";
   llh_converter.convertDeg2XYZ(test_lat, test_lon, 50, x, y, z, param);
   test2(x, y, 45346.7389, 28608.3575);
@@ -140,15 +176,9 @@ int main(int argc, char** argv)
 
   // Test TM
   param.projection_method = llh_converter::ProjectionMethod::TM;
-  param.tm_param.inv_flatten_ratio = 298.257222101;
-  param.tm_param.semi_major_axis = 6378137.0;
-  param.tm_param.scale_factor = 0.9996;
-  param.tm_param.origin_lat_rad = 35.5 * M_PI / 180.;
-  param.tm_param.origin_lon_rad = 135.5 * M_PI / 180.;
-
   std::cout << "Testing TM    ... ";
   llh_converter.convertDeg2XYZ(test_lat, test_lon, 50, x, y, z, param);
   test2(x, y, 0.0, 0.0);
 
-  return 0;
+  return has_failure ? 1 : 0;
 }

--- a/test/height_converter_test.cpp
+++ b/test/height_converter_test.cpp
@@ -86,6 +86,29 @@ int main(int argc, char** argv)
     }
   };
 
+  auto test_throw_contains =
+    [&](const std::string& label, const std::function<void()>& func, const std::string& expected_message) {
+      std::cout << label;
+      try
+      {
+        func();
+        std::cout << "\033[31;1mTEST FAILED : expected exception\033[m" << std::endl;
+        has_failure = true;
+      }
+      catch (const std::exception& e)
+      {
+        if (std::string(e.what()).find(expected_message) != std::string::npos)
+        {
+          std::cout << "\033[32;1mTEST SUCCESS: " << e.what() << "\033[m" << std::endl;
+        }
+        else
+        {
+          std::cout << "\033[31;1mTEST FAILED : unexpected message: " << e.what() << "\033[m" << std::endl;
+          has_failure = true;
+        }
+      }
+    };
+
   // GSIGEO Test
   std::cout << "GSIGEO2011 Test" << std::endl;
   hc.setGeoidType(llh_converter::GeoidType::GSIGEO2011);
@@ -133,9 +156,11 @@ int main(int argc, char** argv)
 
   std::cout << "Out of range geoid error test" << std::endl;
   hc.setGeoidType(llh_converter::GeoidType::GSIGEO2011);
-  test_throw("Testing GSIGEO2011 out of range ... ", [&]() { hc.getGeoidDeg(35.0, 100.0); });
+  test_throw_contains("Testing GSIGEO2011 out of range ... ", [&]() { hc.getGeoidDeg(35.0, 100.0); },
+                      "Error: latitude/longitude is out of range");
   hc.setGeoidType(llh_converter::GeoidType::JPGEO2024);
-  test_throw("Testing JPGEO2024 out of range ... ", [&]() { hc.getGeoidDeg(35.0, 100.0); });
+  test_throw_contains("Testing JPGEO2024 out of range ... ", [&]() { hc.getGeoidDeg(35.0, 100.0); },
+                      "Error: latitude/longitude is out of range");
 
   // LLHConverter test
   std::cout << "LLHConverter Test" << std::endl;
@@ -157,11 +182,13 @@ int main(int argc, char** argv)
   llh_converter::LLHParam tm_param = param;
   tm_param.projection_method = llh_converter::ProjectionMethod::TM;
   tm_param.geoid_type = llh_converter::GeoidType::JPGEO2024;
-  test_throw("Testing LLHConverter JPGEO2024 out of range ... ",
-             [&]() { llh_converter.convertDeg2XYZ(overseas_lat, overseas_lon, 50, x, y, z, tm_param); });
+  test_throw_contains("Testing LLHConverter JPGEO2024 out of range ... ",
+                      [&]() { llh_converter.convertDeg2XYZ(overseas_lat, overseas_lon, 50, x, y, z, tm_param); },
+                      "Error: latitude/longitude is out of range");
   tm_param.geoid_type = llh_converter::GeoidType::GSIGEO2011;
-  test_throw("Testing LLHConverter GSIGEO2011 out of range ... ",
-             [&]() { llh_converter.convertDeg2XYZ(overseas_lat, overseas_lon, 50, x, y, z, tm_param); });
+  test_throw_contains("Testing LLHConverter GSIGEO2011 out of range ... ",
+                      [&]() { llh_converter.convertDeg2XYZ(overseas_lat, overseas_lon, 50, x, y, z, tm_param); },
+                      "Error: latitude/longitude is out of range");
   std::cout << "Testing MGRS  ... ";
   llh_converter.convertDeg2XYZ(test_lat, test_lon, 50, x, y, z, param);
   test2(x, y, 45346.7389, 28608.3575);


### PR DESCRIPTION
## Summary
- replace geoid error handling in GSIGEO2011 / JPGEO2024 from `exit` or silent `NaN` to `std::runtime_error`
- let callers handle out-of-range geoid errors gracefully
- add out-of-range tests for `HeightConverter` and `LLHConverter`