### PR TITLE
feat: support GSIGEO_DATA env var to override hardcoded /usr/share/GSIGEO path

### DIFF
--- a/src/height_converter.cpp
+++ b/src/height_converter.cpp
@@ -107,10 +107,11 @@ void HeightConverter::loadGSIGEOGeoidFile(const std::string& geoid_file)
 
 void HeightConverter::loadGSIGEOGeoidFile()
 {
+  const char* env_dir = std::getenv("GSIGEO_DATA");
 #ifdef _WIN32
-  const std::string dir = "C:/ProgramData/MAP4/geoid";
+  const std::string dir = env_dir ? env_dir : "C:/ProgramData/MAP4/geoid";
 #else
-  const std::string dir = "/usr/share/GSIGEO";
+  const std::string dir = env_dir ? env_dir : "/usr/share/GSIGEO";
 #endif
   gsigeo2011_.loadGeoidMap(dir + "/gsigeo2011_ver2_1.asc");
 }
@@ -122,10 +123,11 @@ void HeightConverter::loadJPGEO2024GeoidFile(const std::string& geoid_file, cons
 
 void HeightConverter::loadJPGEO2024GeoidFile()
 {
+  const char* env_dir = std::getenv("GSIGEO_DATA");
 #ifdef _WIN32
-  const std::string dir = "C:/ProgramData/MAP4/geoid";
+  const std::string dir = env_dir ? env_dir : "C:/ProgramData/MAP4/geoid";
 #else
-  const std::string dir = "/usr/share/GSIGEO";
+  const std::string dir = env_dir ? env_dir : "/usr/share/GSIGEO";
 #endif
   jpgeo2024_.loadGeoidMap(dir + "/JPGEO2024.isg", dir + "/Hrefconv2024.isg");
 }

--- a/src/height_converter.cpp
+++ b/src/height_converter.cpp
@@ -107,7 +107,12 @@ void HeightConverter::loadGSIGEOGeoidFile(const std::string& geoid_file)
 
 void HeightConverter::loadGSIGEOGeoidFile()
 {
-  gsigeo2011_.loadGeoidMap("/usr/share/GSIGEO/gsigeo2011_ver2_1.asc");
+#ifdef _WIN32
+  const std::string dir = "C:/ProgramData/MAP4/geoid";
+#else
+  const std::string dir = "/usr/share/GSIGEO";
+#endif
+  gsigeo2011_.loadGeoidMap(dir + "/gsigeo2011_ver2_1.asc");
 }
 
 void HeightConverter::loadJPGEO2024GeoidFile(const std::string& geoid_file, const std::string& hrefconv_file)
@@ -117,7 +122,12 @@ void HeightConverter::loadJPGEO2024GeoidFile(const std::string& geoid_file, cons
 
 void HeightConverter::loadJPGEO2024GeoidFile()
 {
-  jpgeo2024_.loadGeoidMap("/usr/share/GSIGEO/JPGEO2024.isg", "/usr/share/GSIGEO/Hrefconv2024.isg");
+#ifdef _WIN32
+  const std::string dir = "C:/ProgramData/MAP4/geoid";
+#else
+  const std::string dir = "/usr/share/GSIGEO";
+#endif
+  jpgeo2024_.loadGeoidMap(dir + "/JPGEO2024.isg", dir + "/Hrefconv2024.isg");
 }
 
 double HeightConverter::getGeoidEGM2008(const double& lat_deg, const double& lon_deg)


### PR DESCRIPTION
## 概要

`GSIGEO_DATA` 環境変数を追加し、GSIGEO2011/JPGEO2024 ジオイドデータのパスをハードコードから切り離した。

## 変更内容

`loadGSIGEOGeoidFile()` / `loadJPGEO2024GeoidFile()` において、データディレクトリを以下の優先順位で解決するように変更：

1. `GSIGEO_DATA` 環境変数（セットされている場合）
2. デフォルトパス（Linux: `/usr/share/GSIGEO`、Windows: `C:/ProgramData/MAP4/geoid`）

## 背景

map4_engine_v3 の deploy image から任意のディレクトリに展開して実行する際、`/usr/share/GSIGEO` への書き込みが不要になる。`source` や `sudo apt` なしで動作する自己完結型デプロイを実現するために必要な変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)